### PR TITLE
Update RNReactNativeGetMusicFiles.podspec

### DIFF
--- a/ios/RNReactNativeGetMusicFiles.podspec
+++ b/ios/RNReactNativeGetMusicFiles.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNReactNativeGetMusicFiles
                    DESC
-  s.homepage     = ""
+  s.homepage = "https://github.com/cinder92/react-native-get-music-files"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Update `s.homepage` to avoid error installing pod:

```
The `RNReactNativeGetMusicFiles` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```